### PR TITLE
NSMBe is now on Git, not SVN.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-NSMBe 5.2 SVN
+NSMBe 5.2 Git
 -----------------
 Download NSMBe on NSMBHD: http://nsmbhd.net/?page=download
 


### PR DESCRIPTION
NSMBe is on Git, not SVN.
