### PR TITLE
Update ASM Patcher so that it uses the ARM9 RAM Address specific to each game defined at 0x28 in the ROM header instead of the hardcoded value used by NSMB.

### DIFF
--- a/NSMBe4/Patcher/Arm9BinaryHandler.cs
+++ b/NSMBe4/Patcher/Arm9BinaryHandler.cs
@@ -57,11 +57,11 @@ namespace NSMBe4.Patcher
 
             sections = new List<Arm9BinSection>();
 
-            int copyTableBegin = (int)(f.getUintAt(getCodeSettingsOffs() + 0x00) - 0x02000000u);
-            int copyTableEnd = (int)(f.getUintAt(getCodeSettingsOffs() + 0x04) - 0x02000000u);
-            int dataBegin = (int)(f.getUintAt(getCodeSettingsOffs() + 0x08) - 0x02000000u);
+            int copyTableBegin = (int)(f.getUintAt(getCodeSettingsOffs() + 0x00) - ROM.arm9RAMAddress);
+            int copyTableEnd = (int)(f.getUintAt(getCodeSettingsOffs() + 0x04) - ROM.arm9RAMAddress);
+            int dataBegin = (int)(f.getUintAt(getCodeSettingsOffs() + 0x08) - ROM.arm9RAMAddress);
 
-            newSection(0x02000000, dataBegin, 0x0, 0);
+            newSection((int)ROM.arm9RAMAddress, dataBegin, 0x0, 0);
             sections[0].real = false;
 
             while (copyTableBegin < copyTableEnd)
@@ -92,7 +92,7 @@ namespace NSMBe4.Patcher
                 o.align(4);
             }
 
-            uint sectionTableAddr = 0x02000E00;
+            uint sectionTableAddr = ROM.arm9RAMAddress + 0xE00;
             ByteArrayOutputStream o2 = new ByteArrayOutputStream();
             foreach (Arm9BinSection s in sections)
             {
@@ -116,14 +116,14 @@ namespace NSMBe4.Patcher
 
             byte[] data = o.getArray();
             byte[] sectionTable = o2.getArray();
-            Array.Copy(sectionTable, 0, data, sectionTableAddr - 0x02000000, sectionTable.Length);
+            Array.Copy(sectionTable, 0, data, sectionTableAddr - ROM.arm9RAMAddress, sectionTable.Length);
             f.replace(data, this);
             f.endEdit(this);
 
             f.setUintAt(getCodeSettingsOffs() + 0x00, (uint)sectionTableAddr);
             Console.Out.WriteLine(String.Format("{0:X8} {1:X8}", getCodeSettingsOffs() + 0x04, (uint)o2.getPos() + sectionTableAddr));
             f.setUintAt(getCodeSettingsOffs() + 0x04, (uint)o2.getPos() + sectionTableAddr);
-            f.setUintAt(getCodeSettingsOffs() + 0x08, (uint)(sections[0].len + 0x02000000));
+            f.setUintAt(getCodeSettingsOffs() + 0x08, (uint)(sections[0].len + ROM.arm9RAMAddress));
 
             Console.Out.WriteLine("DONE");
         }
@@ -134,7 +134,7 @@ namespace NSMBe4.Patcher
         {
             // Find the end of the settings
             // This old method doesn't work with The Legendary Starfy :\ -Treeki
-            //return (int)(getUintAt(0x90C) - 0x02000000u);
+            //return (int)(f.getUintAt(0x90C) - ROM.arm9RAMAddress);
             if (_codeSettingsOffs == -1)
             {
                 for (int i = 0; i < 0x8000; i += 4)
@@ -174,7 +174,7 @@ namespace NSMBe4.Patcher
             if(!isCompressed) return;
 
 
-            int decompressionOffs = decompressionRamAddr - 0x02000000;
+            int decompressionOffs = decompressionRamAddr - (int)ROM.arm9RAMAddress;
 
             int compDatSize = (int)(f.getUintAt(decompressionOffs - 8) & 0xFFFFFF);
             int compDatOffs = decompressionOffs - compDatSize;

--- a/NSMBe4/ROM.cs
+++ b/NSMBe4/ROM.cs
@@ -75,6 +75,8 @@ namespace NSMBe4 {
         public static File rsaSigFile;
         public static File headerFile;
 
+        public static uint arm9RAMAddress;
+
         //Download play-friendly mode.
         public static bool dlpMode = false;
 
@@ -92,8 +94,9 @@ namespace NSMBe4 {
 			arm7ovFile = FS.getFileByName("arm7ovt.bin");			
 			arm7ovs = loadOvTable(arm7ovFile);
 			rsaSigFile = FS.getFileByName("rsasig.bin");			
-			headerFile = FS.getFileByName("header.bin");			
-			
+			headerFile = FS.getFileByName("header.bin");
+
+            arm9RAMAddress = headerFile.getUintAt(0x28);
 			
             ByteArrayInputStream header = new ByteArrayInputStream(headerFile.getContents());
             romInternalName = header.ReadString(12);


### PR DESCRIPTION
The 'Run make and insert' feature currently assumes that the ARM9 RAM address is 0x02000000 as in NSMB for all NDS games, however each game's will vary, for example in SM64DS (E) it's 0x02004000 and trying to use the ASM Patcher with these games will not work. Changing it so that it uses the value at 0x28 in the ROM header allows the ASM Patcher to work with games with different ARM9 RAM addresses, eg. SM64DS is now compatible.
